### PR TITLE
User/asroman/metu sparg dataset integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ python mat2dict.py /path/to/TAU_DB/TAU-SRIR_DB/
 The exemplary script is:
 * The `example_script_DCASE2022.py` is a script showing a pipeline to generate data similar to the current DCASE2022 dataset.
 
-The repository is licensed under the [TAU License](LICENSE.md).
-
 ### Using the generated dataset to train the DCASE 2023 Task 3 audio-only baseline you should get results similar to these:
 
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,14 @@ This repository contains several Python file, which in total create a complete d
 * The `make_dataset.py` is the main script in which the whole framework is used to perform the full data generation process.
 * The `utils.py` is an additional file containing complementary functions for other scripts.
 
-Moreover, two object files are included in case the database configuration via `db_config.py` takes too much time:
+Moreover, an object file is included in case the database configuration via `db_config.py` takes too much time:
 * The `db_config_fsd.obj` is a DBConfig class containing information about the database and files for the FSD50K audioset.
-* The `db_config_nigens.obj` is a DBConfig class containing information about the database and files for the NIGENS audioset.
+* you will need to run the `mat2dict.py` script to convert `matlab` files with RIR data into python pickles. 
+
+```
+python mat2dict.py /path/to/TAU_DB/TAU-SRIR_DB/
+``` 
+
 
 The exemplary script is:
 * The `example_script_DCASE2022.py` is a script showing a pipeline to generate data similar to the current DCASE2022 dataset.

--- a/audio_mixer.py
+++ b/audio_mixer.py
@@ -7,10 +7,17 @@ class AudioMixer(object):
             self, params, db_config, mixtures, mixture_setup, audio_format, scenario_out, scenario_interf='target_interf'
             ):
         self._recpath2020 = params['noisepath']
-        self._rooms_paths2020 = ['01_bomb_center','02_gym','03_pb132_paatalo_classroom2','04_pc226_paatalo_office',
-                                  '05_sa203_sahkotalo_lecturehall','06_sc203_sahkotalo_classroom2','07_se201_sahkotalo_classroom',
-                                  '08_se203_sahkotalo_classroom','09_tb103_tietotalo_lecturehall',
-                                  '10_tc352_tietotalo_meetingroom']
+       	self._rooms_paths2020 = {
+                 'bomb_shelter':'01_bomb_center',
+                 'gym':'02_gym',
+                 'pb132':'03_pb132_paatalo_classroom2',
+                 'pc226':'04_pc226_paatalo_office',
+                 'sa203':'05_sa203_sahkotalo_lecturehall',
+                 'sc203':'06_sc203_sahkotalo_classroom2',
+                 'se201':'07_se201_sahkotalo_classroom',
+                 'se203':'08_se203_sahkotalo_classroom',
+                 'tb103':'09_tb103_tietotalo_lecturehall',
+                 'tc352':'10_tc352_tietotalo_meetingroom'}
         self._nb_rooms2020 = len(self._rooms_paths2020)
         self._recpath2019 = params['noisepath']
         self._rooms_paths2019 = ['11_language_center','12_tietotalo','13_reaktori','14_sahkotalo','15_festia']
@@ -54,23 +61,23 @@ class AudioMixer(object):
             print('Adding noise for fold {}'.format(nfold+1))
             rooms = self._mixtures[nfold][0]['roomidx']
             nb_rooms = len(rooms)
-            for nr in range(nb_rooms):
-                nroom = rooms[nr]
+            for inr, nr in enumerate(rooms):#range(nb_rooms):
+                nroom = nr
                 
                 if self._scenarios[2]:
                     print('Loading ambience')
-                    recpath = self._recpath2020 if nroom <=10 else self._recpath2019
-                    roompath = self._rooms_paths2020 if nroom <= 10 else self._rooms_paths2019
-                    roomidx = nroom if nroom <= 10 else nroom-10
-                    ambience, _ = soundfile.read(recpath  + '/' + roompath[roomidx-1] + '/ambience_' + self._mic_format + '_24k_edited.wav')
+                    recpath = self._recpath2020
+                    roompath = self._rooms_paths2020
+                    roomidx = nroom# if nroom <= 10 else nroom-10
+                    ambience, _ = soundfile.read(recpath  + '/' + roompath[roomidx] + '/ambience_' + self._mic_format + '_24k_edited.wav')
                     lSig = np.shape(ambience)[0]
                     nSegs = np.floor(lSig/self._lMix)
                 
-                nb_mixtures = len(self._mixtures[nfold][nr]['mixture'])
+                nb_mixtures = len(self._mixtures[nfold][inr]['mixture'])
                 for nmix in range(nb_mixtures):
                     print('Loading target mixture {}/{} \n'.format(nmix+1,nb_mixtures))
-                    mixture_filename = 'fold{}_room{}_mix{:03}.wav'.format(nfold+1,nr+1,nmix+1)
-                    snr = self._mixtures[nfold][nr]['mixture'][nmix]['snr']
+                    mixture_filename = 'fold{}_room{}_mix{:03}.wav'.format(nfold+1,inr+1,nmix+1)
+                    snr = self._mixtures[nfold][inr]['mixture'][nmix]['snr']
                     
                     target_sig, _ = soundfile.read(self._targetpath + '/' + self._audio_format + '/' + mixture_filename)
                     target_omni_energy = np.sum(np.mean(target_sig,axis=1)**2) if self._audio_format == 'mic' else np.sum(target_sig[:,0]**2)

--- a/example_script_DCASE2022.py
+++ b/example_script_DCASE2022.py
@@ -28,6 +28,10 @@ db_handler = open('db_config_fsd.obj','rb')
 db_config = pickle.load(db_handler)
 db_handler.close()
 
+file = open("rirdata_dict.pkl",'rb')
+db_config._rirdata = pickle.load(file)
+file.close()
+
 # fix the music files (assuming orchset)
 all_music_files = [f for f in os.listdir(params['db_path']) if 'ex' in f]
 tr_music = [f for f in all_music_files if 'Beethoven' not in f]

--- a/example_synth_metu_sparg.py
+++ b/example_synth_metu_sparg.py
@@ -1,0 +1,107 @@
+import sys
+import os
+import glob
+import numpy as np
+# from db_config import DBConfig
+from metadata_synthesizer import MetadataSynthesizer
+from audio_synthesizer import AudioSynthesizer
+from audio_mixer import AudioMixer
+import pickle
+from generation_parameters import get_params
+
+'''
+This script is the first instance of DCASE SELD style synthesis using 32ch from the METU-Sparg dataset
+'''
+
+# use parameter set defined by user
+task_id = '2' # NOTE: to be deprecated soon given the introduction of .yaml files instead
+
+params = get_params(task_id)
+    
+### Create database config based on params (e.g. filelist name etc.)
+# db_config = DBConfig(params)
+    
+# # LOAD DB-config which is already done
+db_handler = open('db_config_fsd.obj','rb')
+db_config = pickle.load(db_handler)
+db_handler.close()
+
+file = open("rirdata_dict.pkl",'rb')
+db_config._rirdata = pickle.load(file)
+file.close()
+
+### add the METU-SPARG room
+file = open("/scratch/data/SELD-data-generator/metusparg/doa_xyz_mic.pkl",'rb') # need a better name
+db_config._rirdata['metu'] = {} 
+db_config._rirdata['metu']['doa_xyz'] = pickle.load(file)
+file.close()
+
+music_dir = os.path.join(params['db_path'], "music")
+# list of train music wave file paths
+tr_wave_files = []
+# Use glob to recursively search for all wave files in the directory and its subdirectories
+for file in glob.glob(os.path.join(music_dir, "train", '**/*.wav'), recursive=True):
+    tr_wave_files.append(file)
+
+# list of test music wave file paths
+ts_wave_files = []
+# Use glob to recursively search for all wave files in the directory and its subdirectories
+for file in glob.glob(os.path.join(music_dir, "test", '**/*.wav'), recursive=True):
+    ts_wave_files.append(file)
+
+tr_samplelist = db_config._samplelist[0]
+i = 0
+sample_list = []
+for sample in tr_samplelist['audiofile']:
+    # print(sample)
+    if 'music/' in sample:
+        sample = '/{}'.format(tr_wave_files[i%len(tr_wave_files)])
+        print(sample)
+        i += 1
+    sample_list.append(sample)
+db_config._samplelist[0]['audiofile'] = np.array(sample_list)
+
+ts_samplelist = db_config._samplelist[1]
+i = 0
+sample_list = []
+for sample in ts_samplelist['audiofile']:
+    print(sample)
+    if 'music/' in sample:
+        sample = '/{}'.format(ts_wave_files[i%len(ts_wave_files)])
+        i += 1
+    sample_list.append(sample)
+db_config._samplelist[1]['audiofile'] = np.array(sample_list)
+
+#create mixture synthesizer class
+noiselessSynth = MetadataSynthesizer(db_config, params, 'target_noiseless')
+    
+#create mixture targets
+mixtures_target, mixture_setup_target, foldlist_target = noiselessSynth.create_mixtures()
+    
+#calculate statistics and create metadata structure
+metadata, stats = noiselessSynth.prepare_metadata_and_stats()
+    
+#write metadata to text files
+noiselessSynth.write_metadata()
+    
+
+if not params['audio_format'] == 'both': # create a dataset of only one data format (FOA or MIC)
+    #create audio synthesis class and synthesize audio files for given mixtures
+    noiselessAudioSynth = AudioSynthesizer(params, mixtures_target, mixture_setup_target, db_config, params['audio_format'])
+    noiselessAudioSynth.synthesize_mixtures()
+        
+    #mix the created audio mixtures with background noise
+    audioMixer = AudioMixer(params, db_config, mixtures_target, mixture_setup_target, params['audio_format'], 'target_noisy')
+    audioMixer.mix_audio()
+else:
+    #create audio synthesis class and synthesize audio files for given mixtures
+    noiselessAudioSynth = AudioSynthesizer(params, mixtures_target, mixture_setup_target, db_config, 'foa')
+    noiselessAudioSynth.synthesize_mixtures()
+    noiselessAudioSynth2 = AudioSynthesizer(params, mixtures_target, mixture_setup_target, db_config, 'mic')
+    noiselessAudioSynth2.synthesize_mixtures()
+        
+    #mix the created audio mixtures with background noise
+    audioMixer = AudioMixer(params, db_config, mixtures_target, mixture_setup_target, 'foa', 'target_noisy')
+    audioMixer.mix_audio()
+    audioMixer2 = AudioMixer(params, db_config, mixtures_target, mixture_setup_target, 'mic', 'target_noisy')
+    audioMixer2.mix_audio()

--- a/generation_parameters.py
+++ b/generation_parameters.py
@@ -1,47 +1,8 @@
 # Parameters used in the data generation process.
-
+import yaml
 
 def get_params(argv='1'):
-    print("SET: {}".format(argv))
-    # ########### default parameters (NIGENS data) ##############
-    params = dict(
-        db_name = 'nigens',  # name of the audio dataset used for data generation
-        rirpath = '/home/iran/SELD-data-generator/TAU_DB/TAU-SRIR_DB',   # path containing Room Impulse Responses (RIRs)
-        mixturepath = 'E:/DCASE2022/TAU_Spatial_RIR_Database_2021/Dataset-NIGENS',  # output path for the generated dataset
-        noisepath = '/home/iran/SELD-data-generator/TAU_DB/TAU-SNoise_DB',  # path containing background noise recordings
-        nb_folds = 2,  # number of folds (default 2 - training and testing)
-        #rooms2fold = [['tc352','sc203','bomb_shelter','pc226','pb132','se203','metu'],
-        rooms2fold = [['metu'],
-                                 ['tb103','sa203','gym']],
-        db_path = 'E:/DCASE2022/TAU_Spatial_RIR_Database_2021/Code/NIGENS',  # path containing audio events to be utilized during data generation
-        max_polyphony = 3,  # maximum number of overlapping sound events
-        active_classes = [0, 1, 2, 3, 5, 6, 8, 9, 10, 11, 12, 13],  # list of sound classes to be used for data generation
-        nb_mixtures_per_fold = [150, 300], # if scalar, same number of mixtures for each fold
-        mixture_duration = 60., #in seconds
-        event_time_per_layer = 40., #in seconds (should be less than mixture_duration)
-        audio_format = 'mic', # 'foa' (First Order Ambisonics) or 'mic' (four microphones) or 'both'
-            )
-        
-
-    # ########### User defined parameters ##############
-    if argv == '1':
-        print("USING DEFAULT PARAMETERS FOR NIGENS DATA\n")
-
-    elif argv == '2': ###### FSD50k DATA
-        params['db_name'] = 'fsd50k'
-        params['db_path']= '/home/iran/datasets/FSD50K'
-        params['mixturepath'] = '/datasets/SELD-dataset'
-        params['active_classes'] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-        params['max_polyphony'] = 2
-
-    elif argv == '3': ###### NIGENS interference data
-        params['active_classes'] = [4, 7, 14] 
-        params['max_polyphony'] = 1
-        
-    else:
-        print('ERROR: unknown argument {}'.format(argv))
-        exit()
-
-    for key, value in params.items():
-        print("\t{}: {}".format(key, value))
+    with open('./yaml/gen_params.yaml', 'r') as file:
+        params = yaml.safe_load(file)
+    # Please define another ./yaml/*.yaml: no more hard coding below please :P
     return params

--- a/generation_parameters.py
+++ b/generation_parameters.py
@@ -10,8 +10,8 @@ def get_params(argv='1'):
         mixturepath = 'E:/DCASE2022/TAU_Spatial_RIR_Database_2021/Dataset-NIGENS',  # output path for the generated dataset
         noisepath = '/home/iran/SELD-data-generator/TAU_DB/TAU-SNoise_DB',  # path containing background noise recordings
         nb_folds = 2,  # number of folds (default 2 - training and testing)
-        rooms2fold = [[10, 6, 1, 4, 3, 8], # FOLD 1, rooms assigned to each fold (0's are ignored)
-                      [9, 5, 2, 0, 0, 0]], # FOLD 2
+        rooms2fold = [['tc352','sc203','bomb_shelter','pc226','pb132','se203'],
+                                 ['tb103','sa203','gym']],
         db_path = 'E:/DCASE2022/TAU_Spatial_RIR_Database_2021/Code/NIGENS',  # path containing audio events to be utilized during data generation
         max_polyphony = 3,  # maximum number of overlapping sound events
         active_classes = [0, 1, 2, 3, 5, 6, 8, 9, 10, 11, 12, 13],  # list of sound classes to be used for data generation

--- a/mat2dict.py
+++ b/mat2dict.py
@@ -1,0 +1,79 @@
+import pickle
+import sys
+import scipy.io
+import mat73
+import numpy as np
+
+
+def main(argv):
+
+    PATH_TO_RIRs = argv[1]
+
+    db_handler = open('db_config_fsd.obj','rb')  
+    db_config = pickle.load(db_handler) 
+    db_handler.close()
+
+    measinfomat = scipy.io.loadmat('{}/measinfo.mat'.format(PATH_TO_RIRs))['measinfo']
+
+    rirdata2room_idx = {1: 0, 2: 1, 3: 2, 4: 3, 5: 4, 6: 5, 8: 6, 9: 7, 10: 8}
+    rirdata2room_idx = {v:k for k,v in rirdata2room_idx.items()}
+    rirdata2room_measinfo = {1: 'bomb_shelter', 2: 'gym', 3: 'pb132', 4: 'pc226', 5: 'sa203', 6: 'sc203', 8: 'se203', 9: 'tb103', 10: 'tc352'}
+
+    # 1. add room names to rirdata_dict
+    rirdata_dict = {}
+    for v in rirdata2room_measinfo.values():
+        rirdata_dict[v] = {}
+        rirdata_dict[v]['doa_xyz'] = None
+        rirdata_dict[v]['dist'] = None
+
+    # 2. add the trajectories to each room 
+    for iroom, room in enumerate(rirdata_dict.keys()):
+
+        #################################
+        #################################
+        #################################
+        # work first with the rir metadata
+        #################################
+        #################################
+        #################################
+
+        trajs_data = db_config._rirdata[iroom][0][2]
+
+        trajs_list = []
+        for traj in trajs_data:
+
+            heights_data = traj
+
+            heights_list = []
+            for height in heights_data:
+
+                heights_list.append(height[0])
+
+            trajs_list.append(heights_list)
+        rirdata_dict[room]['doa_xyz'] = trajs_list
+
+        #################################
+        #################################
+        #################################
+        # now generate a dictionary with the actual rirs
+        #################################
+        #################################
+        #################################
+
+        rirfile = '{}rirs_{:02d}_{}.mat'.format(PATH_TO_RIRs,rirdata2room_idx[iroom],room)
+        rirwavs_mic = mat73.loadmat(rirfile)['rirs']['mic']
+        rirwavs_foa = mat73.loadmat(rirfile)['rirs']['foa']
+        rirwavs = {'mic':rirwavs_mic, 'foa':rirwavs_foa}
+        with open('{}.pkl'.format(rirfile[:-4]), 'wb') as outp:
+            pickle.dump(rirwavs, outp, pickle.HIGHEST_PROTOCOL)
+
+
+    with open('rirdata_dict.pkl', 'wb') as outp:
+        pickle.dump(rirdata_dict, outp, pickle.HIGHEST_PROTOCOL)
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except (ValueError, IOError) as e:
+        sys.exit(e)
+

--- a/metadata_synthesizer.py
+++ b/metadata_synthesizer.py
@@ -62,7 +62,6 @@ class MetadataSynthesizer(object):
             rooms_nf = self._mixture_setup['rooms2folds'][nfold]
             nb_rooms_nf = len(rooms_nf)
             
-            
             idx_active = np.array([])
             for na in range(self._nb_active_classes):
                 idx_active = np.append(idx_active, np.nonzero(self._db_config._samplelist[nfold]['class'] == self._active_classes[na]))

--- a/metusparg/preprocess_sparg.py
+++ b/metusparg/preprocess_sparg.py
@@ -1,0 +1,38 @@
+import os
+import argparse
+
+METU_PATH = "/Users/adrianromanguzman/Documents/repos/SELD-data-generator/spargair/em32"
+
+def main():
+    parser = argparse.ArgumentParser(description='Description of your program')
+    parser.add_argument('microphone', type=str, help='Name of the microphone type to be processed: em32, mic')
+    args = parser.parse_args()
+    microphone = args.microphone
+    mic_nch = 32
+    if microphone == "em32":
+        process_channels = [i for i in range(1, mic_nch)]
+    elif microphone == "mic":
+        process_channels = [6, 10, 26, 22]
+    else:
+        parser.error("You must provide a valid microphone name: em32, mic")
+
+    outter_trayectory_bottom = ["034", "024", "014", "004", "104", "204",
+                                "304", "404", "504", "604", "614", "624",
+                                "634", "644", "654", "664", "564", "464",
+                                "364", "264", "164", "064", "054", "044"]
+    top_height = 5
+    for height in range(0, top_height): # loop through heights
+        for num in outter_trayectory_bottom:
+            # Impulse Reponse to be processed
+            rir_name = num[0] + num[1] + str(int(num[2])-height)
+            # Load the 32 eigenmike IR wavefiles and merge into a multi-channel file
+            cmd_mix_all_ch = ""
+            for ch_idx in process_channels: #range(1,mic_nch+1):
+                cmd_mix_all_ch += f' {os.path.join(METU_PATH, rir_name)}/IR{ch_idx:05}.wav '
+            # SoX -M to merge 32 into multi-channel signal
+            ir_path = os.path.join(METU_PATH, rir_name, f"IR_{microphone}.wav")
+            print("generating", ir_path)
+            os.system(f'sudo sox -M {cmd_mix_all_ch} {ir_path}')
+
+if __name__ == '__main__':
+    main()            

--- a/metusparg/preprocess_sparg.py
+++ b/metusparg/preprocess_sparg.py
@@ -1,7 +1,7 @@
 import os
 import argparse
 
-METU_PATH = "/home/iran/datasets/spargair/em32"
+METU_PATH = "/mnt/ssdt7/RIR-datasets/spargair/em32"
 
 def main():
     parser = argparse.ArgumentParser(description='Description of your program')
@@ -10,7 +10,7 @@ def main():
     microphone = args.microphone
     mic_nch = 32
     if microphone == "em32":
-        process_channels = [i for i in range(1, mic_nch)]
+        process_channels = [i for i in range(1, mic_nch+1)]
     elif microphone == "mic":
         process_channels = [6, 10, 26, 22]
     else:
@@ -27,7 +27,7 @@ def main():
             rir_name = num[0] + num[1] + str(int(num[2])-height)
             # Load the 32 eigenmike IR wavefiles and merge into a multi-channel file
             cmd_mix_all_ch = ""
-            for ch_idx in process_channels: #range(1,mic_nch+1):
+            for ch_idx in process_channels:
                 cmd_mix_all_ch += f' {os.path.join(METU_PATH, rir_name)}/IR{ch_idx:05}.wav '
             # SoX -M to merge 32 into multi-channel signal
             ir_path = os.path.join(METU_PATH, rir_name, f"IR_{microphone}.wav")

--- a/metusparg/sparg_meas_to_pickle.py
+++ b/metusparg/sparg_meas_to_pickle.py
@@ -1,43 +1,22 @@
 import os
-import math
 import pickle
 import librosa
 import numpy as np
 from mpl_toolkits import mplot3d
 import matplotlib.pyplot as plt
 
-def unit_vector(ref, source):
-    """
-    Calculates a unit vector between two points in 3D space
-    """
-    x = source[0] - ref[0]
-    y = source[1] - ref[1]
-    z = source[2] - ref[2]
-    mag = math.sqrt(x**2 + y**2 + z**2)
-    return [x/mag, y/mag, z/mag]
+from sparg_utils import *
 
-def points_distance(ref, source):
-    """
-    Calculates distance between two points in 3D space
-    """
-    return np.sqrt(np.sum((np.array(ref)-np.array(source))**2))
-
-METU_PATH = "/mnt/ssdt7/RIR-datasets/spargair/em32"
-mic_xyz = [(3 - 3) * 0.5, (3 - 2) * 0.3, (3 - 3) * 0.5 + 1.5]
+METU_PATH = "/Users/adrianromanguzman/Documents/repos/SELD-data-generator/spargair/em32"
+mic_xyz = [(3 - 3) * 0.5, (3 - 3) * 0.5, (2 - 2) * 0.3 + 1.5]
 mic_nch = 32
+top_height = 5
 
-rir_meas_data = [
-    '000', '012', '024', '041', '053', '100', '112', '124', '141', '153', '200', '212', '224', '241', '253', '300', '312', '324', '342', '354', '401', '413', '430', '442', '454', '501', '513', '530', '542', '554', '601', '613', '630', '642', '654',
-    '001', '013', '030', '042', '054', '101', '113', '130', '142', '154', '201', '213', '230', '242', '254', '301', '313', '330', '343', '360', '402', '414', '431', '443', '460', '502', '514', '531', '543', '560', '602', '614', '631', '643', '660', 
-    '002', '014', '031', '043', '060', '102', '114', '131', '143', '160', '202', '214', '231', '243', '260', '302', '314', '331', '344', '361', '403', '420', '432', '444', '461', '503', '520', '532', '544', '561', '603', '620', '632', '644', '661', 
-    '003', '020', '032', '044', '061', '103', '120', '132', '144', '161', '203', '220', '232', '244', '261', '303', '320', '333', '350', '362', '404', '421', '433', '450', '462', '504', '521', '533', '550', '562', '604', '621', '633', '650', '662', 
-    '004', '021', '033', '050', '062', '104', '121', '133', '150', '162', '204', '221', '233', '250', '262', '304', '321', '334', '351', '363', '410', '422', '434', '451', '463', '510', '522', '534', '551', '563', '610', '622', '634', '651', '663', 
-    '010', '022', '034', '051', '063', '110', '122', '134', '151', '163', '210', '222', '234', '251', '263', '310', '322', '340', '352', '364', '411', '423', '440', '452', '464', '511', '523', '540', '552', '564', '611', '623', '640', '652', '664', 
-    '011', '023', '040', '052', '064', '111', '123', '140', '152', '164', '211', '223', '240', '252', '264', '311', '323', '341', '353', '400', '412', '424', '441', '453', '500', '512', '524', '541', '553', '600', '612', '624', '641', '653'
-    ]
+outter_trayectory_bottom = ["034", "024", "014", "004", "104", "204", "304", "404", "504", "604", "614", "624", "634", "644", "654", "664", "564", "464", "364", "264", "164", "064", "054", "044"]
 
-outter_trayectory_top = ["062", "061", "060", "160", "260", "360", "460", "560", "660", "661", "662", "663", "664", "564", "464", "364", "264", "164", "064", "063"]
-# inner_trayectory_top = [TBD]
+x_coords = []
+y_coords = []
+z_coords = []
 
 rirdata_dict = {}
 room = "metu"
@@ -46,40 +25,37 @@ rirdata_dict[room]['doa_xyz'] = [[]]
 rirdata_dict[room]['dist'] = [[]]
 rirdata_dict[room]['rir'] = [[]]
 
-x_coords = []
-y_coords = []
-z_coords = []
-
-for height in range(0, 7): # decrease heights
+for height in range(0, top_height): # loop through heights
     heights_list = []
     doa_xyz = []
     hir_list = [] # impulse responses list per height
-    for num in outter_trayectory_top:
+    for num in outter_trayectory_bottom:
         # Coords computed based on documentation.pdf from METU Sparg
         x = (3 - int(num[0])) * 0.5
-        y = (3 - int(num[2])) * 0.3
-        z = (3 - int(num[1])+height) * 0.5 + 1.5 # (1.5) mic height
+        y = (3 - int(num[1])) * 0.5
+        z = (2 - int(num[2])+height) * 0.3 + 1.5
         source_xyz = [x, y, z]
-        doa_xyz.append(unit_vector(mic_xyz, source_xyz))
-        distances = points_distance(mic_xyz, source_xyz)
-        heights_list.append(distances) 
-        rir_name = num[0] + str(int(num[1])-height) + num[2]
+        azi, ele, dist = az_ele_from_source(mic_xyz, source_xyz)
+        uvec_xyz = unit_vector(azi, ele)
+        doa_xyz.append(uvec_xyz)
+        heights_list.append(dist) 
+        rir_name = num[0] + num[1] + str(int(num[2])-height)
         '''
         # Note: uncomment code below to merge IRs into a multi-channel .wav
         # Load the 32 eigenmike IR wavefiles and concat in a single numpy array
         cmd_mix_all_ch = ""
-        for mic_idx in range(1,mic_nch+1):
-            cmd_mix_all_ch += f'{os.path.join(METU_PATH, rir_name)}/IR{mic_idx:05}.wav '
+        for mic_idx in [6,10,26,22]: #range(1,mic_nch+1):
+            cmd_mix_all_ch += f' {os.path.join(METU_PATH, rir_name)}/IR{mic_idx:05}.wav '
         # SoX -M to merge 32 into multi-channel signal
-        ir32ch_path = os.path.join(METU_PATH, rir_name, "IR_32ch.wav")
+        ir32ch_path = os.path.join(METU_PATH, rir_name, "IR_MIC.wav")
         print("generating", ir32ch_path)
         os.system(f'sudo sox -M {cmd_mix_all_ch} {ir32ch_path}')
         '''
-        ir32ch_path = os.path.join(METU_PATH, rir_name, "IR_32ch.wav")
+        print("RIR file: ", rir_name)
+        ir32ch_path = os.path.join(METU_PATH, rir_name, "IR_MIC.wav")
         # ir4ch_path = os.path.join(METU_PATH, rir_name, "IR_MIC.wav")
         irdata, sr = librosa.load(ir32ch_path, mono=False, sr=48000)
         irdata_resamp = librosa.resample(irdata, orig_sr=sr, target_sr=24000)
-        print("Adding RIR with shape", irdata_resamp.shape)
         hir_list.append(irdata_resamp)
         # # Used for plotting only
         # x_coords.append(x)
@@ -89,21 +65,25 @@ for height in range(0, 7): # decrease heights
     rirdata_dict[room]['dist'][0].append(heights_list)
     rirdata_dict[room]['rir'][0].append(hir_list)
 
-# print("doa_xyz info")
-# print("Length list", len(rirdata_dict[room]['doa_xyz']))
-# print("Length inner list", len(rirdata_dict[room]['doa_xyz'][0]))
-
 with open('{}.pkl'.format("rir_MIC"), 'wb') as outp:
     pickle.dump(rirdata_dict[room]['rir'], outp, pickle.HIGHEST_PROTOCOL)
 
 with open('{}.pkl'.format("doa_xyz_MIC"), 'wb') as outp:
     pickle.dump(rirdata_dict[room]['doa_xyz'], outp, pickle.HIGHEST_PROTOCOL)
 
+
 # # Plotting measurements
+# initpoint_xyz = [(3 - int(0)) * 0.5, (3 - int(3)) * 0.5, (2 - 2) * 0.3 + 1.5]
+# az, el, _ = az_ele_from_source(mic_xyz, initpoint_xyz)
+# initpt_xyz = unit_vector(az, el)
 # fig = plt.figure()
 # ax = plt.axes(projection ='3d')
 # # plotting
-# ax.scatter(x_coords, y_coords,z_coords, 'blue')
-# ax.scatter((3 - 3) * 0.5, (3 - 2) * 0.3, (3 - 3) * 0.5 + 1.5, 'red')
+# ax.scatter(x_coords, y_coords, z_coords, 'blue')
+# # ax.scatter(x_coords_inner, y_coords_inner, z_coords_inner)
+# ax.scatter(mic_xyz[0], mic_xyz[1], mic_xyz[2], 'red')
+# ax.quiver(mic_xyz[0], mic_xyz[1], mic_xyz[2], initpt_xyz[0], initpt_xyz[1], initpt_xyz[2])
+# plt.xlabel("X")
+# plt.ylabel("Y")
 # ax.set_title('METU RIR measurements')
-# plt.savefig("metu_meas.png")
+# plt.show()

--- a/metusparg/sparg_meas_to_pickle.py
+++ b/metusparg/sparg_meas_to_pickle.py
@@ -1,4 +1,5 @@
 import os
+import argparse
 import pickle
 import librosa
 import numpy as np
@@ -8,82 +9,58 @@ import matplotlib.pyplot as plt
 from sparg_utils import *
 
 METU_PATH = "/Users/adrianromanguzman/Documents/repos/SELD-data-generator/spargair/em32"
-mic_xyz = [(3 - 3) * 0.5, (3 - 3) * 0.5, (2 - 2) * 0.3 + 1.5]
-mic_nch = 32
-top_height = 5
 
-outter_trayectory_bottom = ["034", "024", "014", "004", "104", "204", "304", "404", "504", "604", "614", "624", "634", "644", "654", "664", "564", "464", "364", "264", "164", "064", "054", "044"]
+def main():
+    parser = argparse.ArgumentParser(description='Description of your program')
+    parser.add_argument('microphone', type=str, help='Name of the microphone type to be processed: em32, mic')
+    args = parser.parse_args()
+    microphone = args.microphone
+    if microphone != "em32" and microphone != "mic":
+        parser.error("You must provide a valid microphone name: em32, mic")
+    # Hard coded bottom trayectory
+    outter_trayectory_bottom = ["034", "024", "014", "004", "104", "204",
+                                "304", "404", "504", "604", "614", "624",
+                                "634", "644", "654", "664", "564", "464",
+                                "364", "264", "164", "064", "054", "044"]
+    top_height = 5
+    mic_xyz = get_mic_xyz()
+    rirdata_dict = {}
+    # Data structure (potentially to be used once this is fully integrated)
+    room = "metu"
+    rirdata_dict[room] = {}
+    rirdata_dict[room]['doa_xyz'] = [[]]
+    rirdata_dict[room]['dist'] = [[]]
+    rirdata_dict[room]['rir'] = [[]]
 
-x_coords = []
-y_coords = []
-z_coords = []
+    for height in range(0, top_height): # loop through heights
+        heights_list = []   # list of heights
+        doa_xyz = []        # list of unit vectors for each doa per height
+        hir_list = []       # impulse responses list per height
+        for num in outter_trayectory_bottom:
+            # Coords computed based on documentation.pdf from METU Sparg
+            x = (3 - int(num[0])) * 0.5
+            y = (3 - int(num[1])) * 0.5
+            z = (2 - int(num[2])+height) * 0.3 + 1.5
+            source_xyz = [x, y, z]
+            azi, ele, dist = az_ele_from_source(mic_xyz, source_xyz)
+            uvec_xyz = unit_vector(azi, ele)
+            doa_xyz.append(uvec_xyz)
+            heights_list.append(dist) 
+            rir_name = num[0] + num[1] + str(int(num[2])-height)
+            print("RIR file: ", rir_name)
+            ir_path = os.path.join(METU_PATH, rir_name, f"IR_{microphone}.wav")
+            irdata, sr = librosa.load(ir_path, mono=False, sr=48000)
+            irdata_resamp = librosa.resample(irdata, orig_sr=sr, target_sr=24000)
+            hir_list.append(irdata_resamp)
+        rirdata_dict[room]['doa_xyz'][0].append(doa_xyz)
+        rirdata_dict[room]['dist'][0].append(heights_list)
+        rirdata_dict[room]['rir'][0].append(hir_list)
 
-rirdata_dict = {}
-room = "metu"
-rirdata_dict[room] = {}
-rirdata_dict[room]['doa_xyz'] = [[]]
-rirdata_dict[room]['dist'] = [[]]
-rirdata_dict[room]['rir'] = [[]]
+    with open('{}.pkl'.format(f"rir_{microphone}"), 'wb') as outp:
+        pickle.dump(rirdata_dict[room]['rir'], outp, pickle.HIGHEST_PROTOCOL)
 
-for height in range(0, top_height): # loop through heights
-    heights_list = []
-    doa_xyz = []
-    hir_list = [] # impulse responses list per height
-    for num in outter_trayectory_bottom:
-        # Coords computed based on documentation.pdf from METU Sparg
-        x = (3 - int(num[0])) * 0.5
-        y = (3 - int(num[1])) * 0.5
-        z = (2 - int(num[2])+height) * 0.3 + 1.5
-        source_xyz = [x, y, z]
-        azi, ele, dist = az_ele_from_source(mic_xyz, source_xyz)
-        uvec_xyz = unit_vector(azi, ele)
-        doa_xyz.append(uvec_xyz)
-        heights_list.append(dist) 
-        rir_name = num[0] + num[1] + str(int(num[2])-height)
-        '''
-        # Note: uncomment code below to merge IRs into a multi-channel .wav
-        # Load the 32 eigenmike IR wavefiles and concat in a single numpy array
-        cmd_mix_all_ch = ""
-        for mic_idx in [6,10,26,22]: #range(1,mic_nch+1):
-            cmd_mix_all_ch += f' {os.path.join(METU_PATH, rir_name)}/IR{mic_idx:05}.wav '
-        # SoX -M to merge 32 into multi-channel signal
-        ir32ch_path = os.path.join(METU_PATH, rir_name, "IR_MIC.wav")
-        print("generating", ir32ch_path)
-        os.system(f'sudo sox -M {cmd_mix_all_ch} {ir32ch_path}')
-        '''
-        print("RIR file: ", rir_name)
-        ir32ch_path = os.path.join(METU_PATH, rir_name, "IR_MIC.wav")
-        # ir4ch_path = os.path.join(METU_PATH, rir_name, "IR_MIC.wav")
-        irdata, sr = librosa.load(ir32ch_path, mono=False, sr=48000)
-        irdata_resamp = librosa.resample(irdata, orig_sr=sr, target_sr=24000)
-        hir_list.append(irdata_resamp)
-        # # Used for plotting only
-        # x_coords.append(x)
-        # y_coords.append(y)
-        # z_coords.append(z)
-    rirdata_dict[room]['doa_xyz'][0].append(doa_xyz)
-    rirdata_dict[room]['dist'][0].append(heights_list)
-    rirdata_dict[room]['rir'][0].append(hir_list)
+    with open('{}.pkl'.format(f"doa_xyz_{microphone}"), 'wb') as outp:
+        pickle.dump(rirdata_dict[room]['doa_xyz'], outp, pickle.HIGHEST_PROTOCOL)
 
-with open('{}.pkl'.format("rir_MIC"), 'wb') as outp:
-    pickle.dump(rirdata_dict[room]['rir'], outp, pickle.HIGHEST_PROTOCOL)
-
-with open('{}.pkl'.format("doa_xyz_MIC"), 'wb') as outp:
-    pickle.dump(rirdata_dict[room]['doa_xyz'], outp, pickle.HIGHEST_PROTOCOL)
-
-
-# # Plotting measurements
-# initpoint_xyz = [(3 - int(0)) * 0.5, (3 - int(3)) * 0.5, (2 - 2) * 0.3 + 1.5]
-# az, el, _ = az_ele_from_source(mic_xyz, initpoint_xyz)
-# initpt_xyz = unit_vector(az, el)
-# fig = plt.figure()
-# ax = plt.axes(projection ='3d')
-# # plotting
-# ax.scatter(x_coords, y_coords, z_coords, 'blue')
-# # ax.scatter(x_coords_inner, y_coords_inner, z_coords_inner)
-# ax.scatter(mic_xyz[0], mic_xyz[1], mic_xyz[2], 'red')
-# ax.quiver(mic_xyz[0], mic_xyz[1], mic_xyz[2], initpt_xyz[0], initpt_xyz[1], initpt_xyz[2])
-# plt.xlabel("X")
-# plt.ylabel("Y")
-# ax.set_title('METU RIR measurements')
-# plt.show()
+if __name__ == '__main__':
+    main()

--- a/metusparg/sparg_meas_to_pickle.py
+++ b/metusparg/sparg_meas_to_pickle.py
@@ -40,7 +40,7 @@ def main():
             # Coords computed based on documentation.pdf from METU Sparg
             x = (3 - int(num[0])) * 0.5
             y = (3 - int(num[1])) * 0.5
-            z = (2 - int(num[2])+height) * 0.3 + 1.5
+            z = (2 - (int(num[2])-height)) * 0.3 + 1.5
             source_xyz = [x, y, z]
             azi, ele, dist = az_ele_from_source(mic_xyz, source_xyz)
             uvec_xyz = unit_vector(azi, ele)

--- a/metusparg/sparg_meas_to_pickle.py
+++ b/metusparg/sparg_meas_to_pickle.py
@@ -1,0 +1,109 @@
+import os
+import math
+import pickle
+import librosa
+import numpy as np
+from mpl_toolkits import mplot3d
+import matplotlib.pyplot as plt
+
+def unit_vector(ref, source):
+    """
+    Calculates a unit vector between two points in 3D space
+    """
+    x = source[0] - ref[0]
+    y = source[1] - ref[1]
+    z = source[2] - ref[2]
+    mag = math.sqrt(x**2 + y**2 + z**2)
+    return [x/mag, y/mag, z/mag]
+
+def points_distance(ref, source):
+    """
+    Calculates distance between two points in 3D space
+    """
+    return np.sqrt(np.sum((np.array(ref)-np.array(source))**2))
+
+METU_PATH = "/mnt/ssdt7/RIR-datasets/spargair/em32"
+mic_xyz = [(3 - 3) * 0.5, (3 - 2) * 0.3, (3 - 3) * 0.5 + 1.5]
+mic_nch = 32
+
+rir_meas_data = [
+    '000', '012', '024', '041', '053', '100', '112', '124', '141', '153', '200', '212', '224', '241', '253', '300', '312', '324', '342', '354', '401', '413', '430', '442', '454', '501', '513', '530', '542', '554', '601', '613', '630', '642', '654',
+    '001', '013', '030', '042', '054', '101', '113', '130', '142', '154', '201', '213', '230', '242', '254', '301', '313', '330', '343', '360', '402', '414', '431', '443', '460', '502', '514', '531', '543', '560', '602', '614', '631', '643', '660', 
+    '002', '014', '031', '043', '060', '102', '114', '131', '143', '160', '202', '214', '231', '243', '260', '302', '314', '331', '344', '361', '403', '420', '432', '444', '461', '503', '520', '532', '544', '561', '603', '620', '632', '644', '661', 
+    '003', '020', '032', '044', '061', '103', '120', '132', '144', '161', '203', '220', '232', '244', '261', '303', '320', '333', '350', '362', '404', '421', '433', '450', '462', '504', '521', '533', '550', '562', '604', '621', '633', '650', '662', 
+    '004', '021', '033', '050', '062', '104', '121', '133', '150', '162', '204', '221', '233', '250', '262', '304', '321', '334', '351', '363', '410', '422', '434', '451', '463', '510', '522', '534', '551', '563', '610', '622', '634', '651', '663', 
+    '010', '022', '034', '051', '063', '110', '122', '134', '151', '163', '210', '222', '234', '251', '263', '310', '322', '340', '352', '364', '411', '423', '440', '452', '464', '511', '523', '540', '552', '564', '611', '623', '640', '652', '664', 
+    '011', '023', '040', '052', '064', '111', '123', '140', '152', '164', '211', '223', '240', '252', '264', '311', '323', '341', '353', '400', '412', '424', '441', '453', '500', '512', '524', '541', '553', '600', '612', '624', '641', '653'
+    ]
+
+outter_trayectory_top = ["062", "061", "060", "160", "260", "360", "460", "560", "660", "661", "662", "663", "664", "564", "464", "364", "264", "164", "064", "063"]
+# inner_trayectory_top = [TBD]
+
+rirdata_dict = {}
+room = "metu"
+rirdata_dict[room] = {}
+rirdata_dict[room]['doa_xyz'] = [[]]
+rirdata_dict[room]['dist'] = [[]]
+rirdata_dict[room]['rir'] = [[]]
+
+x_coords = []
+y_coords = []
+z_coords = []
+
+for height in range(0, 7): # decrease heights
+    heights_list = []
+    doa_xyz = []
+    hir_list = [] # impulse responses list per height
+    for num in outter_trayectory_top:
+        # Coords computed based on documentation.pdf from METU Sparg
+        x = (3 - int(num[0])) * 0.5
+        y = (3 - int(num[2])) * 0.3
+        z = (3 - int(num[1])+height) * 0.5 + 1.5 # (1.5) mic height
+        source_xyz = [x, y, z]
+        doa_xyz.append(unit_vector(mic_xyz, source_xyz))
+        distances = points_distance(mic_xyz, source_xyz)
+        heights_list.append(distances) 
+        rir_name = num[0] + str(int(num[1])-height) + num[2]
+        '''
+        # Note: uncomment code below to merge IRs into a multi-channel .wav
+        # Load the 32 eigenmike IR wavefiles and concat in a single numpy array
+        cmd_mix_all_ch = ""
+        for mic_idx in range(1,mic_nch+1):
+            cmd_mix_all_ch += f'{os.path.join(METU_PATH, rir_name)}/IR{mic_idx:05}.wav '
+        # SoX -M to merge 32 into multi-channel signal
+        ir32ch_path = os.path.join(METU_PATH, rir_name, "IR_32ch.wav")
+        print("generating", ir32ch_path)
+        os.system(f'sudo sox -M {cmd_mix_all_ch} {ir32ch_path}')
+        '''
+        ir32ch_path = os.path.join(METU_PATH, rir_name, "IR_32ch.wav")
+        # ir4ch_path = os.path.join(METU_PATH, rir_name, "IR_MIC.wav")
+        irdata, sr = librosa.load(ir32ch_path, mono=False, sr=48000)
+        irdata_resamp = librosa.resample(irdata, orig_sr=sr, target_sr=24000)
+        print("Adding RIR with shape", irdata_resamp.shape)
+        hir_list.append(irdata_resamp)
+        # # Used for plotting only
+        # x_coords.append(x)
+        # y_coords.append(y)
+        # z_coords.append(z)
+    rirdata_dict[room]['doa_xyz'][0].append(doa_xyz)
+    rirdata_dict[room]['dist'][0].append(heights_list)
+    rirdata_dict[room]['rir'][0].append(hir_list)
+
+# print("doa_xyz info")
+# print("Length list", len(rirdata_dict[room]['doa_xyz']))
+# print("Length inner list", len(rirdata_dict[room]['doa_xyz'][0]))
+
+with open('{}.pkl'.format("rir_MIC"), 'wb') as outp:
+    pickle.dump(rirdata_dict[room]['rir'], outp, pickle.HIGHEST_PROTOCOL)
+
+with open('{}.pkl'.format("doa_xyz_MIC"), 'wb') as outp:
+    pickle.dump(rirdata_dict[room]['doa_xyz'], outp, pickle.HIGHEST_PROTOCOL)
+
+# # Plotting measurements
+# fig = plt.figure()
+# ax = plt.axes(projection ='3d')
+# # plotting
+# ax.scatter(x_coords, y_coords,z_coords, 'blue')
+# ax.scatter((3 - 3) * 0.5, (3 - 2) * 0.3, (3 - 3) * 0.5 + 1.5, 'red')
+# ax.set_title('METU RIR measurements')
+# plt.savefig("metu_meas.png")

--- a/metusparg/sparg_meas_to_pickle.py
+++ b/metusparg/sparg_meas_to_pickle.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 
 from sparg_utils import *
 
-METU_PATH = "/home/iran/datasets/spargair/em32"
+METU_PATH = "/mnt/ssdt7/RIR-datasets/spargair/em32"
 
 def main():
     parser = argparse.ArgumentParser(description='Description of your program')

--- a/metusparg/sparg_utils.py
+++ b/metusparg/sparg_utils.py
@@ -20,12 +20,24 @@ def az_ele_from_source(ref_point, src_point):
 def unit_vector(azimuth, elevation):
     """
     Compute unit vector given the azimuth and elevetion of source in 3D space
+    Args:
+        azimuth (float)
+        elevation (float)
+    Returns:
+        A list representing the coordinate points xyz in 3D space
     """
     x = math.cos(elevation) * math.cos(azimuth)
     y = math.cos(elevation) * math.sin(azimuth)
     z = math.sin(elevation)
     return [x, y, z]
 
+def get_mic_xyz():
+    """
+    Get em32 microphone coordinates in 3D space
+    """
+    return [(3 - 3) * 0.5, (3 - 3) * 0.5, (2 - 2) * 0.3 + 1.5]
+
+# Full set of measurements from METU Sparg dataset
 rir_meas_data = [
     '000', '012', '024', '041', '053', '100', '112', '124', '141', '153', '200', '212', '224', '241', '253', '300', '312', '324', '342', '354', '401', '413', '430', '442', '454', '501', '513', '530', '542', '554', '601', '613', '630', '642', '654',
     '001', '013', '030', '042', '054', '101', '113', '130', '142', '154', '201', '213', '230', '242', '254', '301', '313', '330', '343', '360', '402', '414', '431', '443', '460', '502', '514', '531', '543', '560', '602', '614', '631', '643', '660', 

--- a/metusparg/sparg_utils.py
+++ b/metusparg/sparg_utils.py
@@ -1,0 +1,37 @@
+import math
+
+def az_ele_from_source(ref_point, src_point):
+    """
+    Calculates the azimuth and elevation between a reference point and a source point in 3D space
+    Args:
+        ref_point (list): A list of three floats representing the x, y, and z coordinates of the reference point
+        src_point (list): A list of three floats representing the x, y, and z coordinates of the other point
+    Returns:
+        A tuple of two floats representing the azimuth and elevation angles in radians plus distance between reference and source point
+    """
+    dx = src_point[0] - ref_point[0]
+    dy = src_point[1] - ref_point[1]
+    dz = src_point[2] - ref_point[2]
+    azimuth = math.atan2(dy, dx)
+    distance = math.sqrt(dx**2 + dy**2 + dz**2)
+    elevation = math.asin(dz/distance)
+    return azimuth, elevation, distance
+
+def unit_vector(azimuth, elevation):
+    """
+    Compute unit vector given the azimuth and elevetion of source in 3D space
+    """
+    x = math.cos(elevation) * math.cos(azimuth)
+    y = math.cos(elevation) * math.sin(azimuth)
+    z = math.sin(elevation)
+    return [x, y, z]
+
+rir_meas_data = [
+    '000', '012', '024', '041', '053', '100', '112', '124', '141', '153', '200', '212', '224', '241', '253', '300', '312', '324', '342', '354', '401', '413', '430', '442', '454', '501', '513', '530', '542', '554', '601', '613', '630', '642', '654',
+    '001', '013', '030', '042', '054', '101', '113', '130', '142', '154', '201', '213', '230', '242', '254', '301', '313', '330', '343', '360', '402', '414', '431', '443', '460', '502', '514', '531', '543', '560', '602', '614', '631', '643', '660', 
+    '002', '014', '031', '043', '060', '102', '114', '131', '143', '160', '202', '214', '231', '243', '260', '302', '314', '331', '344', '361', '403', '420', '432', '444', '461', '503', '520', '532', '544', '561', '603', '620', '632', '644', '661', 
+    '003', '020', '032', '044', '061', '103', '120', '132', '144', '161', '203', '220', '232', '244', '261', '303', '320', '333', '350', '362', '404', '421', '433', '450', '462', '504', '521', '533', '550', '562', '604', '621', '633', '650', '662', 
+    '004', '021', '033', '050', '062', '104', '121', '133', '150', '162', '204', '221', '233', '250', '262', '304', '321', '334', '351', '363', '410', '422', '434', '451', '463', '510', '522', '534', '551', '563', '610', '622', '634', '651', '663', 
+    '010', '022', '034', '051', '063', '110', '122', '134', '151', '163', '210', '222', '234', '251', '263', '310', '322', '340', '352', '364', '411', '423', '440', '452', '464', '511', '523', '540', '552', '564', '611', '623', '640', '652', '664', 
+    '011', '023', '040', '052', '064', '111', '123', '140', '152', '164', '211', '223', '240', '252', '264', '311', '323', '341', '353', '400', '412', '424', '441', '453', '500', '512', '524', '541', '553', '600', '612', '624', '641', '653'
+    ]

--- a/yaml/gen_params.yaml
+++ b/yaml/gen_params.yaml
@@ -1,0 +1,15 @@
+idb_name: fsd50k
+rirpath: /scratch/data/TAU-SRIR/TAU-SRIR_DB
+mixturepath: /scratch/data/FSD50K-DCASE-SYNTH-EM32
+noisepath: /scratch/data/TAU-SRIR/TAU-SNoise_DB
+nb_folds: 2
+rooms2fold:
+  - - metu
+  - - metu
+db_path: /scratch/data/FSD50K/FSD50K_DCASE
+max_polyphony: 3
+active_classes: [0, 1, 2, 3, 5, 6, 8, 9, 10, 11, 12]
+nb_mixtures_per_fold: [15, 30]
+mixture_duration: 60.0
+event_time_per_layer: 40.0
+audio_format: mic


### PR DESCRIPTION
 Take em32 RIRs data and integrate it into DCASE synth format:

METU Sparg data parameters:
```
Number of trajectories = 1
Number of heights = 5
Number of samples per IR (Nsamp)= 48000
Number of channels per IR (Nch)= 32 (em32), 4 (MIC)
```

Data structures brief:
```
doa_xyz = list_of_trayectories_([list_of_heights_([x, y, z])])
rir = list_of_trayectories_([list_of_heights_(np.array(Nch, Nsamp)])
```

Assumptions:
- Circular trajectory TAU RIR is equivalent to a square trajectory in METU Sparg
- MIC raw channels correspond to channels 6,10,26,22 (one-based) from the Sparg eigenmike data

![meas_3d](https://github.com/iranroman/SELD-data-generator/assets/26074300/a12ffb2f-0814-439e-8813-a93a5bc1179d)
