### PR TITLE
Implement the use of background ambient noise recorded in the TAU rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 
 > [!WARNING]
-> SpatialScaper is still undergoing active development. We have done our due diligence to test that  `example_generation.py` works as expected. However, please open an issue and describe any errors you encounter. Also, make sure to pull often, as we are actively adding more features. 
+> SpatialScaper is still undergoing active development. We have done our due diligence to test that  `example_generation.py` works as expected. However, please open an issue and describe any errors you encounter. Also, make sure to pull often, as we are actively adding more features. Note: You'll need 100GB of storage space to comfortably setup and run the DCASE Task 3 data generation pipeline. 
 
 **Guides**
 - [Requirements and Installation](#requirements-and-installation)
@@ -106,16 +106,17 @@ import os
 # Constants
 NSCAPES = 20  # Number of soundscapes to generate
 FOREGROUND_DIR = "datasets/sound_event_datasets/FSD50K_FMA"  # Directory with FSD50K foreground sound files
-BACKGROUND_DIR = ""  # Directory for background sound files, not used in this example
-RIR_DIR = "datasets/rir_datasets"  # Directory containing Room Impulse Response (RIR) files
+RIR_DIR = (
+    "datasets/rir_datasets"  # Directory containing Room Impulse Response (RIR) files
+)
 ROOM = "bomb_shelter"  # Initial room setting, change according to available rooms listed below
 FORMAT = "mic"  # Output format specifier
 N_EVENTS_MEAN = 15  # Mean number of foreground events in a soundscape
 N_EVENTS_STD = 6  # Standard deviation of the number of foreground events
 DURATION = 60.0  # Duration in seconds of each soundscape, customizable by the user
-SR = 24000  # Sampling rate for the audio files
+SR = 24000  # SpatialScaper default sampling rate for the audio files
 OUTPUT_DIR = "output"  # Directory to store the generated soundscapes
-REF_DB = -65  # Reference decibel level for normalization
+REF_DB = -65  # Reference decibel level for the background ambient noise. Try making this random too!
 
 # List of possible rooms to use for soundscape generation. Change 'ROOM' variable to one of these:
 # "metu", "bomb_shelter", "gym", "pb132", "pc226", "sa203", "sc203", "se203", "tb103", "tc352"
@@ -136,13 +137,11 @@ def generate_soundscape(index):
     ssc = ss.Scaper(
         DURATION,
         FOREGROUND_DIR,
-        BACKGROUND_DIR,
         RIR_DIR,
-        ROOM,
         FORMAT,
-        SR,
+        ROOM,
         max_event_overlap=2,
-        speed_limit=2.0, # in meters per second
+        speed_limit=2.0,  # in meters per second
     )
     ssc.ref_db = REF_DB
 
@@ -151,10 +150,10 @@ def generate_soundscape(index):
 
     # Add a random number of foreground events, based on the specified mean and standard deviation.
     n_events = int(np.random.normal(N_EVENTS_MEAN, N_EVENTS_STD))
-    n_events = n_events if n_events > 0 else 1 # n_events should be greater than zero
+    n_events = n_events if n_events > 0 else 1  # n_events should be greater than zero
 
     for _ in range(n_events):
-        ssc.add_event() # randomly choosing and spatializing an FSD50K sound event
+        ssc.add_event()  # randomly choosing and spatializing an FSD50K sound event
 
     audiofile = os.path.join(OUTPUT_DIR, FORMAT, track_name)
     labelfile = os.path.join(OUTPUT_DIR, "labels", track_name)

--- a/example_generation.py
+++ b/example_generation.py
@@ -15,7 +15,9 @@ N_EVENTS_STD = 6  # Standard deviation of the number of foreground events
 DURATION = 60.0  # Duration in seconds of each soundscape, customizable by the user
 SR = 24000  # SpatialScaper default sampling rate for the audio files
 OUTPUT_DIR = "output"  # Directory to store the generated soundscapes
-REF_DB = -65  # Reference decibel level for the background ambient noise. Try making this random too!
+REF_DB = (
+    -65
+)  # Reference decibel level for the background ambient noise. Try making this random too!
 
 # List of possible rooms to use for soundscape generation. Change 'ROOM' variable to one of these:
 # "metu", "bomb_shelter", "gym", "pb132", "pc226", "sa203", "sc203", "se203", "tb103", "tc352"

--- a/example_generation.py
+++ b/example_generation.py
@@ -5,18 +5,17 @@ import os
 # Constants
 NSCAPES = 20  # Number of soundscapes to generate
 FOREGROUND_DIR = "datasets/sound_event_datasets/FSD50K_FMA"  # Directory with FSD50K foreground sound files
-BACKGROUND_DIR = ""  # Directory for background sound files, not used in this example
 RIR_DIR = (
     "datasets/rir_datasets"  # Directory containing Room Impulse Response (RIR) files
 )
-ROOM = "se203"  # Initial room setting, change according to available rooms listed below
+ROOM = "bomb_shelter"  # Initial room setting, change according to available rooms listed below
 FORMAT = "mic"  # Output format specifier
 N_EVENTS_MEAN = 15  # Mean number of foreground events in a soundscape
 N_EVENTS_STD = 6  # Standard deviation of the number of foreground events
 DURATION = 60.0  # Duration in seconds of each soundscape, customizable by the user
-SR = 24000  # Sampling rate for the audio files
+SR = 24000  # SpatialScaper default sampling rate for the audio files
 OUTPUT_DIR = "output"  # Directory to store the generated soundscapes
-REF_DB = -65  # Reference decibel level for normalization
+REF_DB = -65  # Reference decibel level for the background ambient noise. Try making this random too!
 
 # List of possible rooms to use for soundscape generation. Change 'ROOM' variable to one of these:
 # "metu", "bomb_shelter", "gym", "pb132", "pc226", "sa203", "sc203", "se203", "tb103", "tc352"
@@ -37,11 +36,9 @@ def generate_soundscape(index):
     ssc = ss.Scaper(
         DURATION,
         FOREGROUND_DIR,
-        BACKGROUND_DIR,
         RIR_DIR,
-        ROOM,
         FORMAT,
-        SR,
+        ROOM,
         max_event_overlap=2,
         speed_limit=2.0,  # in meters per second
     )

--- a/scripts/prepare_rirs.py
+++ b/scripts/prepare_rirs.py
@@ -89,7 +89,7 @@ def download_and_extract(url, extract_to):
 
 
 def prepare_metu(dataset_path):
-    spargpath = Path(dataset_path) / "original_RIRs" / "spargair" / "em32"
+    spargpath = Path(dataset_path) / "source_data" / "spargair" / "em32"
     nEMchans = 32
     XYZs = os.listdir(spargpath)
 
@@ -289,21 +289,21 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    os.makedirs(Path(args.path) / "original_RIRs", exist_ok=True)
+    os.makedirs(Path(args.path) / "source_data", exist_ok=True)
     os.makedirs(Path(args.path) / "spatialscaper_RIRs", exist_ok=True)
 
     # METU
-    download_and_extract(METU_URL, Path(args.path) / "original_RIRs")
+    download_and_extract(METU_URL, Path(args.path) / "source_data")
     prepare_metu(Path(args.path))
 
     # TAU
-    dest_path = Path(args.path) / "original_RIRs"
+    dest_path = Path(args.path) / "source_data"
     download_tau(dest_path)
     dest_path_sofa = Path(args.path) / "spatialscaper_RIRs"
     prepare_tau(dest_path, dest_path_sofa)
 
     # ARNI
-    dest_path = Path(args.path) / "original_RIRs"
-    download_and_extract(ARNI_URL, Path(args.path) / "original_RIRs")
+    dest_path = Path(args.path) / "source_data"
+    download_and_extract(ARNI_URL, Path(args.path) / "source_data")
     dest_path_sofa = Path(args.path) / "spatialscaper_RIRs"
     prepare_arni(dest_path, dest_path_sofa)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     classifiers=[
         "License :: Creative Commons Attribution 4.0",
         "Programming Language :: Python",
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
         "Topic :: Multimedia :: Sound/Audio :: Analysis",

--- a/spatialscaper/core.py
+++ b/spatialscaper/core.py
@@ -65,7 +65,7 @@ Event = namedtuple(
 
 # Paths for room SOFA files
 __SPATIAL_SCAPER_RIRS_DIR__ = "spatialscaper_RIRs"
-__PATH_TO_AMBIENT_NOISE_FILES__ = os.path.join("source_data","TAU-SNoise_DB")
+__PATH_TO_AMBIENT_NOISE_FILES__ = os.path.join("source_data", "TAU-SNoise_DB")
 __ROOM_RIR_FILE__ = {
     "metu": "metu_sparg_em32.sofa",
     "arni": "arni_mic.sofa",
@@ -114,7 +114,7 @@ class Scaper:
             rir_dir (str): Directory path containing Room Impulse Response (RIR) files to spatialize sound
                 events in rooms. Default is an empty string.
             room (str): Identifier for the room where the scape will be simulated. Default is 'metu'.
-            use_room_ambient_noise (bool): whether the background noise will be sourced from the room's 
+            use_room_ambient_noise (bool): whether the background noise will be sourced from the room's
                 ambient recording. If True, background_dir is ignored. Default is True
             fmt (str): Output format specification, e.g., 'mic' for tetrahedral microphone. Default is 'mic'.
             sr (int): Sampling rate of the output audio in Hertz. Default is 24000 Hz.
@@ -170,15 +170,25 @@ class Scaper:
         path_to_ambient_noise_files = os.path.join(
             self.rir_dir, __PATH_TO_AMBIENT_NOISE_FILES__
         )
-        all_ambient_noise_files = glob.glob(os.path.join(path_to_ambient_noise_files,'*','*'))
-        if self.format == 'mic':
-            ambient_noise_format_files = [f for f in all_ambient_noise_files if 'tetra' in f]
-        elif self.format == 'foa':
-            ambient_noise_format_files = [f for f in all_ambient_noise_files if 'foa' in f]
-        if self.room == 'bomb_shelter':
-            room_ambient_noise_file = [f for f in ambient_noise_format_files if 'bomb_center' in f]
+        all_ambient_noise_files = glob.glob(
+            os.path.join(path_to_ambient_noise_files, "*", "*")
+        )
+        if self.format == "mic":
+            ambient_noise_format_files = [
+                f for f in all_ambient_noise_files if "tetra" in f
+            ]
+        elif self.format == "foa":
+            ambient_noise_format_files = [
+                f for f in all_ambient_noise_files if "foa" in f
+            ]
+        if self.room == "bomb_shelter":
+            room_ambient_noise_file = [
+                f for f in ambient_noise_format_files if "bomb_center" in f
+            ]
         else:
-            room_ambient_noise_file = [f for f in ambient_noise_format_files if self.room in f]
+            room_ambient_noise_file = [
+                f for f in ambient_noise_format_files if self.room in f
+            ]
         assert len(room_ambient_noise_file) < 2
         if room_ambient_noise_file:
             return room_ambient_noise_file[0]
@@ -204,7 +214,9 @@ class Scaper:
             source_file = self.get_path_to_room_ambient_noise()
             ambient_noise_duration = librosa.get_duration(path=source_file)
             if ambient_noise_duration > self.duration:
-                source_time = round(random.uniform(0,ambient_noise_duration-self.duration))
+                source_time = round(
+                    random.uniform(0, ambient_noise_duration - self.duration)
+                )
             else:
                 source_time = None
         else:
@@ -666,7 +678,7 @@ class Scaper:
                 xS = xS[: len(x)]
 
             # standardize the spatialized audio
-            event_scale = db2multiplier(self.ref_db + event.snr,np.mean(np.abs(xS)))
+            event_scale = db2multiplier(self.ref_db + event.snr, np.mean(np.abs(xS)))
             xS = event_scale * xS
 
             # add to out_audio
@@ -698,20 +710,24 @@ class Scaper:
         return out_audio, labels
 
     def get_background_noise(self, out_audio):
-
         for ievent, event in enumerate(self.bg_events):
             if not event.source_file:
                 ambient = self.generate_noise(event)
             else:
                 if event.source_time is not None:
-                    ambient, _ = librosa.load(event.source_file,sr=self.sr,offset=event.source_time,duration=event.event_duration)
+                    ambient, _ = librosa.load(
+                        event.source_file,
+                        sr=self.sr,
+                        offset=event.source_time,
+                        duration=event.event_duration,
+                    )
                 else:
-                    ambient, _ = librosa.load(event.source_file, sr= self.sr)
-                    total_samples = int( self.duration * self.sr ) 
-                    repeats = -(-total_samples// len(ambient)) # ceiling division
+                    ambient, _ = librosa.load(event.source_file, sr=self.sr)
+                    total_samples = int(self.duration * self.sr)
+                    repeats = -(-total_samples // len(ambient))  # ceiling division
                     ambient = np.tile(ambient, repeats)[:total_samples]
-                ambient = ambient[:,np.newaxis]
-            scale = db2multiplier(self.ref_db + event.snr,np.mean(np.abs(ambient)))
+                ambient = ambient[:, np.newaxis]
+            scale = db2multiplier(self.ref_db + event.snr, np.mean(np.abs(ambient)))
             out_audio += scale * ambient
         return out_audio
 

--- a/spatialscaper/core.py
+++ b/spatialscaper/core.py
@@ -721,7 +721,7 @@ class Scaper:
                         offset=event.source_time,
                         duration=event.event_duration,
                     )
-                else:
+                else: # repeat ambient file until scape duration 
                     ambient, _ = librosa.load(event.source_file, sr=self.sr)
                     total_samples = int(self.duration * self.sr)
                     repeats = -(-total_samples // len(ambient))  # ceiling division

--- a/spatialscaper/core.py
+++ b/spatialscaper/core.py
@@ -1,6 +1,7 @@
 import os
 import math
 import random
+import glob
 from collections import namedtuple
 
 import librosa
@@ -15,7 +16,7 @@ from .utils import (
     new_event_exceeds_max_overlap,
     count_leading_zeros_in_period,
     generate_trajectory,
-    db2scale,
+    db2multiplier,
     traj_2_ir_idx,
     find_indices_of_change,
     IR_normalizer,
@@ -64,6 +65,7 @@ Event = namedtuple(
 
 # Paths for room SOFA files
 __SPATIAL_SCAPER_RIRS_DIR__ = "spatialscaper_RIRs"
+__PATH_TO_AMBIENT_NOISE_FILES__ = os.path.join("source_data","TAU-SNoise_DB")
 __ROOM_RIR_FILE__ = {
     "metu": "metu_sparg_em32.sofa",
     "arni": "arni_mic.sofa",
@@ -84,10 +86,11 @@ class Scaper:
         self,
         duration=60,
         foreground_dir="",
-        background_dir="",
         rir_dir="",
-        room="metu",
         fmt="mic",
+        room="metu",
+        use_room_ambient_noise=True,
+        background_dir=None,
         sr=24000,
         DCASE_format=True,
         max_event_overlap=2,
@@ -107,10 +110,12 @@ class Scaper:
         Args:
             duration (float): The duration of the soundscape in seconds. Default is 60 seconds.
             foreground_dir (str): Directory path containing foreground sound files. Default is an empty string.
-            background_dir (str): Directory path containing background sound files. Default is an empty string.
+            background_dir (str): Directory path containing background sound files. Default is None.
             rir_dir (str): Directory path containing Room Impulse Response (RIR) files to spatialize sound
                 events in rooms. Default is an empty string.
             room (str): Identifier for the room where the scape will be simulated. Default is 'metu'.
+            use_room_ambient_noise (bool): whether the background noise will be sourced from the room's 
+                ambient recording. If True, background_dir is ignored. Default is True
             fmt (str): Output format specification, e.g., 'mic' for tetrahedral microphone. Default is 'mic'.
             sr (int): Sampling rate of the output audio in Hertz. Default is 24000 Hz.
             DCASE_format (bool): Flag to enable formatting of output labels for DCASE challenges compatibility.
@@ -136,6 +141,7 @@ class Scaper:
         self.background_dir = background_dir
         self.rir_dir = rir_dir
         self.room = room
+        self.use_room_ambient_noise = use_room_ambient_noise
         self.format = fmt
         self.sr = sr
         self.DCASE_format = DCASE_format
@@ -160,29 +166,61 @@ class Scaper:
 
         self.max_sample_attempts = max_sample_attempts
 
+    def get_path_to_room_ambient_noise(self):
+        path_to_ambient_noise_files = os.path.join(
+            self.rir_dir, __PATH_TO_AMBIENT_NOISE_FILES__
+        )
+        all_ambient_noise_files = glob.glob(os.path.join(path_to_ambient_noise_files,'*','*'))
+        if self.format == 'mic':
+            ambient_noise_format_files = [f for f in all_ambient_noise_files if 'tetra' in f]
+        elif self.format == 'foa':
+            ambient_noise_format_files = [f for f in all_ambient_noise_files if 'foa' in f]
+        if self.room == 'bomb_shelter':
+            room_ambient_noise_file = [f for f in ambient_noise_format_files if 'bomb_center' in f]
+        else:
+            room_ambient_noise_file = [f for f in ambient_noise_format_files if self.room in f]
+        assert len(room_ambient_noise_file) < 2
+        if room_ambient_noise_file:
+            return room_ambient_noise_file[0]
+        else:
+            return random.choice(ambient_noise_format_files)
+
     def add_background(self):
         """
         Adds a background event to the soundscape.
         This method sets fixed values for event time, duration, and
         SNR, and adds the event to the background events list.
         """
-        event_time = ("const", 0)
-        event_duration = ("const", self.duration)
+        label = None
         snr = ("const", 0)
         role = "background"
         pitch_shift = None
         time_stretch = None
+        event_time = ("const", 0)
+        event_duration = ("const", self.duration)
+        event_position = None
+
+        if self.use_room_ambient_noise:
+            source_file = self.get_path_to_room_ambient_noise()
+            ambient_noise_duration = librosa.get_duration(path=source_file)
+            if ambient_noise_duration > self.duration:
+                source_time = round(random.uniform(0,ambient_noise_duration-self.duration))
+            else:
+                source_time = None
+        else:
+            source_file = None
+            source_time = None
 
         self.bg_events.append(
             Event(
-                label=None,
-                source_file=None,
-                source_time=None,
+                label=label,
+                source_file=source_file,
+                source_time=source_time,
                 event_time=event_time[1],
                 event_duration=event_duration[1],
-                event_position=None,
+                event_position=event_position,
                 snr=snr[1],
-                role="background",
+                role=role,
                 pitch_shift=pitch_shift,
                 time_stretch=time_stretch,
             )
@@ -541,22 +579,20 @@ class Scaper:
         else:
             return all_irs
 
-    def generate_noise(self, audio):
+    def generate_noise(self, event):
         """
-        Generates and adds noise to the provided audio based on the background events.
+        Generates noise to be used as background ambient.
 
         Args:
-            audio (numpy.ndarray): The audio to which noise will be added.
+            event : The event named tuple with metadat about the background noise.
 
         Returns:
-            numpy.ndarray: The audio with added noise.
+            numpy.ndarray: The generated noise.
         """
-        for event in self.bg_events:
-            if not event.source_file:
-                audio += db2scale(self.ref_db + event.snr) * np.random.normal(
-                    0, 1, (int(event.event_duration * self.sr), self.nchans)
-                )
-        return audio
+        noise_signal = np.random.normal(
+            0, 1, (int(event.event_duration * self.sr), self.nchans)
+        )
+        return noise_signal
 
     def synthesize_events_and_labels(self, all_irs, all_ir_xyzs, out_audio):
         """
@@ -604,7 +640,7 @@ class Scaper:
             irs = irs[ir_idx]
             ir_xyzs = ir_xyzs[ir_idx]
 
-            # load and normalize audio signal by its norm
+            # load and normalize audio signal to have peak of 1
             x, _ = librosa.load(event.source_file, sr=self.sr)
             x = x[: int(event.event_duration * self.sr)]
             x = x / np.max(np.abs(x))
@@ -630,8 +666,8 @@ class Scaper:
                 xS = xS[: len(x)]
 
             # standardize the spatialized audio
-            event_scale = db2scale(self.ref_db + event.snr)
-            xS = (event_scale / np.std(xS)) * xS
+            event_scale = db2multiplier(self.ref_db + event.snr,np.mean(np.abs(xS)))
+            xS = event_scale * xS
 
             # add to out_audio
             onsamp = int(event.event_time * self.sr)
@@ -660,6 +696,24 @@ class Scaper:
         labels = sort_matrix_by_columns(np.vstack(all_labels))
 
         return out_audio, labels
+
+    def get_background_noise(self, out_audio):
+
+        for ievent, event in enumerate(self.bg_events):
+            if not event.source_file:
+                ambient = self.generate_noise(event)
+            else:
+                if event.source_time is not None:
+                    ambient, _ = librosa.load(event.source_file,sr=self.sr,offset=event.source_time,duration=event.event_duration)
+                else:
+                    ambient, _ = librosa.load(event.source_file, sr= self.sr)
+                    total_samples = int( self.duration * self.sr ) 
+                    repeats = -(-total_samples// len(ambient)) # ceiling division
+                    ambient = np.tile(ambient, repeats)[:total_samples]
+                ambient = ambient[:,np.newaxis]
+            scale = db2multiplier(self.ref_db + event.snr,np.mean(np.abs(ambient)))
+            out_audio += scale * ambient
+        return out_audio
 
     def generate(self, audiopath, labelpath):
         """
@@ -693,8 +747,8 @@ class Scaper:
         # initialize output audio array
         out_audio = np.zeros((int(self.duration * self.sr), self.nchans))
 
-        # add background noise
-        out_audio = self.generate_noise(out_audio)
+        # add background ambience
+        out_audio = self.get_background_noise(out_audio)
 
         # sort foreground events by onset time
         self.fg_events = sorted(self.fg_events, key=lambda x: x.event_time)

--- a/spatialscaper/core.py
+++ b/spatialscaper/core.py
@@ -721,7 +721,7 @@ class Scaper:
                         offset=event.source_time,
                         duration=event.event_duration,
                     )
-                else: # repeat ambient file until scape duration 
+                else:  # repeat ambient file until scape duration
                     ambient, _ = librosa.load(event.source_file, sr=self.sr)
                     total_samples = int(self.duration * self.sr)
                     repeats = -(-total_samples // len(ambient))  # ceiling division

--- a/spatialscaper/utils.py
+++ b/spatialscaper/utils.py
@@ -507,7 +507,7 @@ def IR_normalizer(IRs):
         impulse_responses = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
         normalized_IRs = IR_normalizer(impulse_responses)
     """
-    E = np.sqrt(np.sum(np.power(IRs, 2), axis=-1, keepdims=True))
+    E = np.sqrt(np.sum(np.power(np.abs(IRs), 2), axis=-1, keepdims=True))
     return IRs / np.mean(E, axis=-2, keepdims=True)
 
 
@@ -581,25 +581,22 @@ def traj_2_ir_idx(XYZs, trajectory):
 
     return indices
 
-
-def db2scale(db):
+def db2multiplier(db, x):
     """
-    Converts a value in decibels (dB) to a linear scale factor.
-
-    This function is commonly used in audio signal processing to convert dB values, which represent a logarithmic
-    measure of relative amplitude, to a linear scale. This linear scale is often needed for direct manipulation of
-    audio signal amplitudes.
+    Calculates the multiplier factor from a decibel (dB) value that, when applied to x,
+    adjusts its amplitude to reflect the specified dB. The relationship is 
+    based on the formula 20 * log10(factor * x) ≈ db
 
     Args:
-        db (float): The value in decibels to be converted.
+        db (float): The target decibel change to be applied.
+        x  (float): The original amplitude of x
 
     Returns:
-        float: The corresponding linear scale factor.
+        float: The multiplier factor.
 
-    The conversion is based on the formula: 10^(db/20), which is derived from the decibel definition
-    for power ratios and the relationship between power and amplitude.
     """
-    return 10 ** (db / 20)
+    return 10 ** (db / 20) / x
+
 
 
 def generate_trajectory(xyz_start, xyz_end, npoints, shape):

--- a/spatialscaper/utils.py
+++ b/spatialscaper/utils.py
@@ -581,10 +581,11 @@ def traj_2_ir_idx(XYZs, trajectory):
 
     return indices
 
+
 def db2multiplier(db, x):
     """
     Calculates the multiplier factor from a decibel (dB) value that, when applied to x,
-    adjusts its amplitude to reflect the specified dB. The relationship is 
+    adjusts its amplitude to reflect the specified dB. The relationship is
     based on the formula 20 * log10(factor * x) ≈ db
 
     Args:
@@ -596,7 +597,6 @@ def db2multiplier(db, x):
 
     """
     return 10 ** (db / 20) / x
-
 
 
 def generate_trajectory(xyz_start, xyz_end, npoints, shape):

--- a/spatialscaper/version.py
+++ b/spatialscaper/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = "0.1"
-version = "0.1.0"
+version = "0.1.1"


### PR DESCRIPTION
This PR resolves issue #45 

Changes required include:

* definition of `db2multiplier` in `spatialscaper/utils.py`, which calculates the multiplier factor from a decibel (dB) value that, when applied to x, adjusts its amplitude to reflect the specified dB. The relationship is based on the formula 20 * log10(factor * x) ≈ db
* renaming `datasets/rir_datasets/original_RIRs` to `datasets/rir_datasets/source_data`, as these files include more than just RIRs (i.e. the background ambient noise wav files). 
* changing the library's development status to beta given that now is public.
* updating version to 0.1.1 given this non-trivial change in the library's output. 

@sivannavis @beasteers @ChrisIck @adrianSRoman please review, make suggestions and approve so that we can merge with main. 