### PR TITLE
Enable METU FOA generation using a temporary google drive link with the sofa file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ python scripts/prepare_rirs.py
 
 **Attention:** the first time setup takes some time ⏳, we recommend running under a `screen` or `tmux` session.
 
-Note: stay tuned as we will soon release the A2B ambisonics encoder. In the meantime, download the METU FOA sofa file from this [google drive link](https://drive.google.com/file/d/1zamCd6OR6Tr5M40RdDhswYbT1wbGo2ZO/view?usp=sharing). Place alongside all other sofa files that `prepare_rirs.py` generates under `SpatialScaper/datasets/rir_datasets/spatialscaper_RIRs`. 
+Note: stay tuned as we will soon release our A2B ambisonics encoder. In the meantime, download the METU FOA sofa file from this [google drive link](https://drive.google.com/file/d/1zamCd6OR6Tr5M40RdDhswYbT1wbGo2ZO/view?usp=sharing). Place alongside all other sofa files that `prepare_rirs.py` generates under `SpatialScaper/datasets/rir_datasets/spatialscaper_RIRs`. 
 
 <details>
 <summary>Full descriptions of available rooms </summary>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- omit in toc -->
-# Spatial scaper: a library to simulate and augment soundscapes for sound event localization and detection in realistic rooms.
+# SpatialScaper: a library to simulate and augment soundscapes for sound event localization and detection in realistic rooms.
 [![Platform](https://img.shields.io/badge/Platform-linux-lightgrey?logo=linux)](https://www.linux.org/)
 [![Python](https://img.shields.io/badge/Python-3.8%2B-orange?logo=python)](https://www.python.org/)	
 [![arXiv](https://img.shields.io/badge/Arxiv-2401.03497-blueviolet?logo=arxiv)](https://arxiv.org/abs/2401.12238)
@@ -64,6 +64,8 @@ python scripts/prepare_rirs.py
 ```
 
 **Attention:** the first time setup takes some time ⏳, we recommend running under a `screen` or `tmux` session.
+
+Note: stay tuned as we will soon release the A2B ambisonics encoder. In the meantime, download the METU FOA sofa file from this [google drive link](https://drive.google.com/file/d/1zamCd6OR6Tr5M40RdDhswYbT1wbGo2ZO/view?usp=sharing). Place alongside all other sofa files that `prepare_rirs.py` generates under `SpatialScaper/datasets/rir_datasets/spatialscaper_RIRs`. 
 
 <details>
 <summary>Full descriptions of available rooms </summary>
@@ -177,5 +179,59 @@ If you find our SpatialScaper library useful, please cite the following paper:
   booktitle={IEEE International Conference on Acoustics, Speech and Signal Processing (ICASSP)},
   year={2024},
   organization={IEEE}
+}
+```
+
+Also cite the RIR and sound event databases that SpatialScaper uses.
+
+```
+@dataset{politis_2022_6408611,
+  author       = {Politis, Archontis and
+                  Adavanne, Sharath and
+                  Virtanen, Tuomas},
+  title        = {{TAU Spatial Room Impulse Response Database (TAU- 
+                   SRIR DB)}},
+  month        = apr,
+  year         = 2022,
+  publisher    = {Zenodo},
+  doi          = {10.5281/zenodo.6408611},
+  url          = {https://doi.org/10.5281/zenodo.6408611}
+}
+
+@dataset{orhun_olgun_2019_2635758,
+  author       = {Orhun Olgun and
+                  Huseyin Hacihabiboglu},
+  title        = {{METU SPARG Eigenmike em32 Acoustic Impulse 
+                   Response Dataset v0.1.0}},
+  month        = apr,
+  year         = 2019,
+  publisher    = {Zenodo},
+  version      = {0.1.0},
+  doi          = {10.5281/zenodo.2635758},
+  url          = {https://doi.org/10.5281/zenodo.2635758}
+}
+
+@article{mckenzie2021dataset,
+  title={Dataset of spatial room impulse responses in a variable acoustics room for six degrees-of-freedom rendering and analysis},
+  author={McKenzie, Thomas and McCormack, Leo and Hold, Christoph},
+  journal={arXiv preprint arXiv:2111.11882},
+  year={2021}
+}
+
+@article{fonseca2021fsd50k,
+  title={Fsd50k: an open dataset of human-labeled sound events},
+  author={Fonseca, Eduardo and Favory, Xavier and Pons, Jordi and Font, Frederic and Serra, Xavier},
+  journal={IEEE/ACM Transactions on Audio, Speech, and Language Processing},
+  volume={30},
+  pages={829--852},
+  year={2021},
+  publisher={IEEE}
+}
+
+@article{defferrard2016fma,
+  title={FMA: A dataset for music analysis},
+  author={Defferrard, Micha{\"e}l and Benzi, Kirell and Vandergheynst, Pierre and Bresson, Xavier},
+  journal={arXiv preprint arXiv:1612.01840},
+  year={2016}
 }
 ```

--- a/example_generation.py
+++ b/example_generation.py
@@ -8,11 +8,11 @@ FOREGROUND_DIR = "datasets/sound_event_datasets/FSD50K_FMA"  # Directory with FS
 RIR_DIR = (
     "datasets/rir_datasets"  # Directory containing Room Impulse Response (RIR) files
 )
-ROOM = "bomb_shelter"  # Initial room setting, change according to available rooms listed below
-FORMAT = "mic"  # Output format specifier: could be 'mic' or 'foa'
+ROOM = "metu"  # Initial room setting, change according to available rooms listed below
+FORMAT = "foa"  # Output format specifier: could be 'mic' or 'foa'
 N_EVENTS_MEAN = 15  # Mean number of foreground events in a soundscape
 N_EVENTS_STD = 6  # Standard deviation of the number of foreground events
-DURATION = 60.0  # Duration in seconds of each soundscape, customizable by the user
+DURATION = 60.0  # Duration in seconds of each soundscape
 SR = 24000  # SpatialScaper default sampling rate for the audio files
 OUTPUT_DIR = "output"  # Directory to store the generated soundscapes
 REF_DB = (
@@ -33,7 +33,7 @@ REF_DB = (
 
 # Function to generate a soundscape
 def generate_soundscape(index):
-    track_name = f"fold5_room1_mix{index+1:03d}"
+    track_name = f"fold1_room1_mix{index+1:03d}"
     # Initialize Scaper. 'max_event_overlap' controls the maximum number of overlapping sound events.
     ssc = ss.Scaper(
         DURATION,

--- a/scripts/prepare_rirs.py
+++ b/scripts/prepare_rirs.py
@@ -92,7 +92,6 @@ def download_and_extract(url, extract_to):
 
 def prepare_metu(dataset_path):
     spargpath = Path(dataset_path) / "source_data" / "spargair" / "em32"
-    nEMchans = 32
     XYZs = os.listdir(spargpath)
 
     def XYZ_2_xyz(XYZ):
@@ -110,8 +109,8 @@ def prepare_metu(dataset_path):
 
         wavpath = spargpath / XYZ
         X = []
-        for i in range(nEMchans):
-            wavfile = wavpath / f"IR{i+1:05d}.wav"
+        for ichan in [5, 9, 25, 21]: # Specific channels for 'mic' format
+            wavfile = wavpath / f"IR{ichan+1:05d}.wav"
             x, sr = sf.read(wavfile)
             X.append(x)
         IRs.append(np.array(X))

--- a/scripts/prepare_rirs.py
+++ b/scripts/prepare_rirs.py
@@ -35,6 +35,8 @@ NTAU_ROOMS = 9
 TAU_DB_NAME = "TAU-SRIR-DB-SOFA"
 ARNI_DB_NAME = "ARNI-SRIR-DB-SOFA"
 
+__TETRA_CHANS_IN_EM32__ = [5, 9, 25, 21]
+
 
 def create_single_sofa_file(aud_fmt, tau_db_dir, sofa_db_dir, db_name):
     db_dir = sofa_db_dir
@@ -109,13 +111,13 @@ def prepare_metu(dataset_path):
 
         wavpath = spargpath / XYZ
         X = []
-        for ichan in [5, 9, 25, 21]: # Specific channels for 'mic' format
+        for ichan in __TETRA_CHANS_IN_EM32__:  # Specific channels for 'mic' format
             wavfile = wavpath / f"IR{ichan+1:05d}.wav"
             x, sr = sf.read(wavfile)
             X.append(x)
         IRs.append(np.array(X))
 
-    filepath = Path(dataset_path) / "spatialscaper_RIRs" / "metu_sparg_em32.sofa"
+    filepath = Path(dataset_path) / "spatialscaper_RIRs" / "metu_sparg_mic.sofa"
     rirs = np.array(IRs)
     source_pos = np.array(xyzs)
     mic_pos = np.array([[0, 0, 0]])
@@ -229,7 +231,7 @@ def create_single_sofa_file_arni(aud_fmt, arni_db_dir, sofa_db_dir, room="ARNI")
             # Append data depending on the audio format
             if aud_fmt == "mic":
                 rirs.append(
-                    ir_data_resampled[[5, 9, 25, 21], :]
+                    ir_data_resampled[__TETRA_CHANS_IN_EM32__, :]
                 )  # Specific channels for 'mic' format
             else:  # 'foa' format
                 rirs.append(ir_data_resampled[:4])

--- a/spatialscaper/core.py
+++ b/spatialscaper/core.py
@@ -67,7 +67,7 @@ Event = namedtuple(
 __SPATIAL_SCAPER_RIRS_DIR__ = "spatialscaper_RIRs"
 __PATH_TO_AMBIENT_NOISE_FILES__ = os.path.join("source_data", "TAU-SNoise_DB")
 __ROOM_RIR_FILE__ = {
-    "metu": "metu_sparg_em32.sofa",
+    "metu": "metu_sparg_{fmt}.sofa",
     "arni": "arni_{fmt}.sofa",
     "bomb_shelter": "bomb_shelter_{fmt}.sofa",
     "gym": "gym_{fmt}.sofa",
@@ -547,18 +547,11 @@ class Scaper:
         Returns:
             numpy.ndarray: An array of XYZ coordinates for the impulse response positions.
         """
-        if self.format == "foa" and self.room == "metu":
-            room_sofa_path = os.path.join(
-                self.rir_dir,
-                __SPATIAL_SCAPER_RIRS_DIR__,
-                "metu_sparg_foa.sofa",
-            )
-        else:
-            room_sofa_path = os.path.join(
-                self.rir_dir,
-                __SPATIAL_SCAPER_RIRS_DIR__,
-                __ROOM_RIR_FILE__[self.room].format(fmt=self.format),
-            )
+        room_sofa_path = os.path.join(
+            self.rir_dir,
+            __SPATIAL_SCAPER_RIRS_DIR__,
+            __ROOM_RIR_FILE__[self.room].format(fmt=self.format),
+        )
         return load_pos(room_sofa_path, doas=False)
 
     def get_room_irs_wav_xyz(self, wav=True, pos=True):
@@ -572,18 +565,11 @@ class Scaper:
         Returns:
             tuple: A tuple containing the impulse responses, their sampling rate, and their XYZ positions.
         """
-        if self.format == "foa" and self.room == "metu":
-            room_sofa_path = os.path.join(
-                self.rir_dir,
-                __SPATIAL_SCAPER_RIRS_DIR__,
-                "metu_sparg_foa.sofa",
-            )
-        else:
-            room_sofa_path = os.path.join(
-                self.rir_dir,
-                __SPATIAL_SCAPER_RIRS_DIR__,
-                __ROOM_RIR_FILE__[self.room].format(fmt=self.format),
-            )
+        room_sofa_path = os.path.join(
+            self.rir_dir,
+            __SPATIAL_SCAPER_RIRS_DIR__,
+            __ROOM_RIR_FILE__[self.room].format(fmt=self.format),
+        )
         all_irs, ir_sr, all_ir_xyzs = load_rir_pos(room_sofa_path, doas=False)
         ir_sr = ir_sr.data[0]
         all_irs = all_irs.data

--- a/spatialscaper/core.py
+++ b/spatialscaper/core.py
@@ -548,14 +548,17 @@ class Scaper:
             numpy.ndarray: An array of XYZ coordinates for the impulse response positions.
         """
         if self.format == "foa" and self.room == "metu":
-            raise ValueError(
-                '"metu" room is currently only supported in mic (tetrahedral) format. please check again soon.'
+            room_sofa_path = os.path.join(
+                self.rir_dir,
+                __SPATIAL_SCAPER_RIRS_DIR__,
+                "metu_sparg_foa.sofa",
             )
-        room_sofa_path = os.path.join(
-            self.rir_dir,
-            __SPATIAL_SCAPER_RIRS_DIR__,
-            __ROOM_RIR_FILE__[self.room].format(fmt=self.format),
-        )
+        else:
+            room_sofa_path = os.path.join(
+                self.rir_dir,
+                __SPATIAL_SCAPER_RIRS_DIR__,
+                __ROOM_RIR_FILE__[self.room].format(fmt=self.format),
+            )
         return load_pos(room_sofa_path, doas=False)
 
     def get_room_irs_wav_xyz(self, wav=True, pos=True):
@@ -570,14 +573,17 @@ class Scaper:
             tuple: A tuple containing the impulse responses, their sampling rate, and their XYZ positions.
         """
         if self.format == "foa" and self.room == "metu":
-            raise ValueError(
-                '"metu" room is currently only supported in mic (tetrahedral) format. please check again soon.'
+            room_sofa_path = os.path.join(
+                self.rir_dir,
+                __SPATIAL_SCAPER_RIRS_DIR__,
+                "metu_sparg_foa.sofa",
             )
-        room_sofa_path = os.path.join(
-            self.rir_dir,
-            __SPATIAL_SCAPER_RIRS_DIR__,
-            __ROOM_RIR_FILE__[self.room].format(fmt=self.format),
-        )
+        else:
+            room_sofa_path = os.path.join(
+                self.rir_dir,
+                __SPATIAL_SCAPER_RIRS_DIR__,
+                __ROOM_RIR_FILE__[self.room].format(fmt=self.format),
+            )
         all_irs, ir_sr, all_ir_xyzs = load_rir_pos(room_sofa_path, doas=False)
         ir_sr = ir_sr.data[0]
         all_irs = all_irs.data
@@ -769,7 +775,7 @@ class Scaper:
         """
 
         all_irs, ir_sr, all_ir_xyzs = self.get_room_irs_wav_xyz()
-        all_irs = self.get_format_irs(all_irs)
+        all_irs = self.get_format_irs(all_irs, self.format)
         self.nchans = all_irs.shape[1]  # a bit ugly but works for now
 
         # initialize output audio array

--- a/spatialscaper/core.py
+++ b/spatialscaper/core.py
@@ -593,22 +593,6 @@ class Scaper:
             ir_sr = self.sr
         return all_irs, ir_sr, all_ir_xyzs
 
-    def get_format_irs(self, all_irs, fmt="mic"):
-        """
-        Retrieves impulse responses according to the specified format.
-
-        Args:
-            all_irs (numpy.ndarray): Array of all impulse responses.
-            fmt (str): The format for retrieving impulse responses (e.g., 'mic').
-
-        Returns:
-            numpy.ndarray: An array of impulse responses formatted according to the specified format.
-        """
-        if fmt == "mic" and self.room == "metu":
-            return all_irs[:, [5, 9, 25, 21], :]
-        else:
-            return all_irs
-
     def generate_noise(self, event):
         """
         Generates noise to be used as background ambient.
@@ -775,7 +759,6 @@ class Scaper:
         """
 
         all_irs, ir_sr, all_ir_xyzs = self.get_room_irs_wav_xyz()
-        all_irs = self.get_format_irs(all_irs, self.format)
         self.nchans = all_irs.shape[1]  # a bit ugly but works for now
 
         # initialize output audio array

--- a/spatialscaper/version.py
+++ b/spatialscaper/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = "0.1"
-version = "0.1.3"
+version = "0.1.4"


### PR DESCRIPTION
Our `prepare_rirs.py` script can currently create SOFA file for all the rooms we currently support in MIC and FOA format, except for METU. METU only released the RIRs in MIC format. Therefore there is the need to process the MIC data and produce an FOA format. 

This PR enables METU FOA data generation in SpatialScaper by distributing a sofa file we generated using the [`array2sh` algorithm from Sparta](https://leomccormack.github.io/sparta-site/docs/plugins/sparta-suite/). This is also an acceptable approach given METU's Creative Commons Attribution-NonCommercial-ShareAlike 4.0 license. SpatialScaper users are reminded in the README that they should cite the original METU dataset release in work that uses SpatialScaper.

This is a temporary solution as we finalize the release of our A2B encoder, which will allow for the creation of the METU FOA sofa file. 