### PR TITLE
Leave out classes parameter for event simulation

### DIFF
--- a/spatialscaper/core.py
+++ b/spatialscaper/core.py
@@ -98,6 +98,7 @@ class Scaper:
         ref_db=-60,
         speed_limit=1.5,
         max_sample_attempts=100,
+        leave_out_classes=[],
     ):
         """
         Initializes a SpatialScaper object.
@@ -128,6 +129,7 @@ class Scaper:
                 from a starting to an end point. Default is 1.5.
             max_sample_attempts (int): Maximum attempts to place a sound event at a specific point in time
                 without exceeding max_event_overlap, before giving up . Default is 100.
+            leave_out_classes (list): List of sound event classes to ignore in a simulation. Default is [].
 
         Attributes:
             fg_events (list): Initialized as an empty list to hold foreground event specifications.
@@ -149,6 +151,7 @@ class Scaper:
             self.label_rate = __DCASE_LABEL_RATE__
         self.max_event_overlap = max_event_overlap
         self.max_event_dur = max_event_dur
+        self.leave_out_classes = leave_out_classes
         self.ref_db = ref_db
 
         self.fg_events = []
@@ -157,10 +160,10 @@ class Scaper:
         fg_label_list = get_label_list(self.foreground_dir)
         if self.DCASE_format:
             self.fg_labels = {
-                l: __DCASE_SOUND_EVENT_CLASSES__[l] for l in fg_label_list
+                l: __DCASE_SOUND_EVENT_CLASSES__[l] for l in fg_label_list if l not in self.leave_out_classes 
             }
         else:
-            self.fg_labels = {l: i for i, l in enumerate(fg_label_list)}
+            self.fg_labels = {l: i for i, l in enumerate(fg_label_list) if l not in self.leave_out_classes }
 
         self.speed_limit = speed_limit
 

--- a/spatialscaper/core.py
+++ b/spatialscaper/core.py
@@ -163,7 +163,7 @@ class Scaper:
                 l: __DCASE_SOUND_EVENT_CLASSES__[l] for l in fg_label_list if l not in self.leave_out_classes 
             }
         else:
-            self.fg_labels = {l: i for i, l in enumerate(fg_label_list) if l not in self.leave_out_classes }
+            self.fg_labels = {l: i for i, l in enumerate(fg_label_list)}
 
         self.speed_limit = speed_limit
 


### PR DESCRIPTION
This PR proposes adding a filter to ignore sound classes in simulation. Users may encounter this feature useful as some tasks in the development of SELD systems may require understanding behaviors and/or pitfalls that occur on some sound classes (not all).

The default value for the proposed parameter should be an empty list i.e `[]`. The users may specify a custom list, which will ignore the classes contained by the list following the DCASE event class naming convention.